### PR TITLE
🐛 Fix - 게시글 사용자 정보 잘못 불러지는 거 수정

### DIFF
--- a/src/main/java/gdg/pium/domain/post/dto/response/PostInfoResponse.java
+++ b/src/main/java/gdg/pium/domain/post/dto/response/PostInfoResponse.java
@@ -28,8 +28,8 @@ public class PostInfoResponse {
     public static PostInfoResponse of(Post post, User user, List<String> images, Boolean liked) {
         return PostInfoResponse.builder()
                 .postId(post.getId())
-                .userName(user.getNickname())
-                .userProfileImageUrl(user.getProfileImageUrl())
+                .userName(post.getUser().getNickname())
+                .userProfileImageUrl(post.getUser().getProfileImageUrl())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .nickname(user.getNickname())


### PR DESCRIPTION
## 해결한 이슈
- #20 

## 내용
- 게시글 작성자 이름, 이미지 url 을 반환하도록 수정